### PR TITLE
Treat code style violations as errors

### DIFF
--- a/.mvn/google_checks.xml
+++ b/.mvn/google_checks.xml
@@ -18,7 +18,7 @@
 <module name = "Checker">
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="warning"/>
+    <property name="severity" value="error"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Excludes all 'module-info.java' files              -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,12 +45,24 @@ We recommend IntelliJ IDEA Community, because all of its plugins and
 configurations possibilities, here's [the website](https://www.jetbrains.com/idea/download).
 But feel free to use Eclipse or other IDE of your choice.
 
-### Check-style
+### Code style
 
-We use Google Java Style Guide. If your IDE is IntelliJ, there's a plugin
-that can be very helpful. Take a look at
-[this page](https://plugins.jetbrains.com/plugin/8527-google-java-format)
-or search directly on the IDE Plugins menu.
+Our Java code is formatted following the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
+A formatter and plugins based on it for Eclipse and IntelliJ are available and  make writing
+style-conformant code quite easy. Check the installation notes on the
+[formatter's project page](https://github.com/google/google-java-format).
+
+We configured a tool to validate changes submitted to us in accordance to our style guide. **Passing
+such validation, however, doesn't mean that the code conforms to the style guide**, as some rules
+cannot be checked by this tool. We ask you to check if your code adheres to the following rules
+before submitting it.
+
+- [2.2 File encoding: UTF-8](https://google.github.io/styleguide/javaguide.html#s2.2-file-encoding)
+- [5.2.2 Class names](https://google.github.io/styleguide/javaguide.html#s5.2.2-class-names)
+- [5.2.3 Method names](https://google.github.io/styleguide/javaguide.html#s5.2.3-method-names)
+- [5.2.4 Constant names](https://google.github.io/styleguide/javaguide.html#s5.2.4-constant-names)
+- [5.3 Camel case: defined](https://google.github.io/styleguide/javaguide.html#s5.3-camel-case)
+- [6.1 @Override: always used](https://google.github.io/styleguide/javaguide.html#s6.1-override-annotation)
 
 ## Run this application
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
 		<skip.unit.tests>false</skip.unit.tests>
 		<jacoco.skip>true</jacoco.skip>
 		<checkstyle.skip>true</checkstyle.skip>
+    <checkstyle.failsOnError>true</checkstyle.failsOnError>
+		<checkstyle.includeTestSourceDirectory>true</checkstyle.includeTestSourceDirectory>
 		<jacoco.output.data>${project.build.directory}/coverage-reports</jacoco.output.data>
 		<timestamp>${maven.build.timestamp}</timestamp>
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
@@ -325,9 +327,12 @@
 				</dependencies>
 				<configuration>
 					<skip>${checkstyle.skip}</skip>
+					<failsOnError>${checkstyle.failsOnError}</failsOnError>
+					<includeTestSourceDirectory>
+						${checkstyle.includeTestSourceDirectory}
+					</includeTestSourceDirectory>
 					<configLocation>.mvn/google_checks.xml</configLocation>
 					<consoleOutput>true</consoleOutput>
-					<failsOnError>true</failsOnError>
 					<linkXRef>false</linkXRef>
 				</configuration>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -345,27 +345,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
-			<plugin>
-				<groupId>net.revelc.code</groupId>
-				<artifactId>impsort-maven-plugin</artifactId>
-				<version>1.7.0</version>
-				<configuration>
-					<groups>java.,javax.,org.,com.</groups>
-					<staticGroups>java,*</staticGroups>
-					<staticAfter>true</staticAfter>
-					<removeUnused>true</removeUnused>
-					<lineEnding>LF</lineEnding>
-				</configuration>
-				<executions>
-					<execution>
-						<id>sort-imports</id>
-						<goals>
-							<goal>sort</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 		<finalName>backend-start-api</finalName>
 	</build>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Configure the Checkstyle plugin to validate test classes and generate errors when a code style violation is detected.

Point to install instructions for the `google-java-format` plugin and document Checkstyle limitations.

Fixes [FSADT2-61](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT2-61)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Running `./mvnw --no-transfer-progress checkstyle:checkstyle -Dcheckstyle.skip=false --file pom.xml` in the project's root folder in two situations:

1. All files as they are (all Java classes have their imports ordered as expected)
2. Changing the order of the imports of one Java class.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
