### PR TITLE
ci: newman runner workflow

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -251,7 +251,7 @@ jobs:
           allow_issue_writing: false
           fail_action: false
 
-  test-api:
+  api-tests:
     name: Newman API tests runner
     needs:
       - deploy-test

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -275,12 +275,12 @@ jobs:
 
       - name: Run Postman Collection
         run: |
-          newman run test/postman/starting-api.postman_collection.json -e test/postman/starting-api.postman_environment.json --suppress-exit-code -r htmlextra --reporter-htmlextra-export testArtifacts/api-tests-report.html
+          newman run test/postman/starting-api.postman_collection.json -e test/postman/starting-api.postman_environment.json --env-var "releaseVer=test=${{ env.NRBESTAPI_VERSION }}" --suppress-exit-code -r htmlextra --reporter-htmlextra-export testArtifacts/api-tests-report.html
 
       - name: Output the results
         uses: actions/upload-artifact@v2
         with:
-          name: Reports
+          name: API test report
           path: testArtifacts
 
   # https://github.com/snyk/cli, https://github.com/snyk/actions

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -162,11 +162,23 @@ jobs:
           distribution: 'temurin'
 
       - name: Conventional Changelog Update
+        continue-on-error: true
         uses: TriPSs/conventional-changelog-action@v3
         id: changelog
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           output-file: 'CHANGELOG.md'
+          skip-version-file: 'true'
+          skip-commit: 'true'
+          git-push: 'false'
+
+      - name: Only Tag Generation
+        continue-on-error: true
+        uses: TriPSs/conventional-changelog-action@v3
+        if: ${{ steps.changelog.outputs.skipped == 'true' || steps.changelog.outcome != 'success' }}
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          output-file: 'false'
           skip-version-file: 'true'
           skip-commit: 'true'
           git-push: 'false'

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -251,6 +251,38 @@ jobs:
           allow_issue_writing: false
           fail_action: false
 
+  test-api:
+    name: Newman API tests runner
+    needs:
+      - deploy-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install newman
+        run: |
+          npm install -g newman
+          npm install -g newman-reporter-htmlextra
+
+      - name: Make Directory for Test Results
+        run: mkdir -p testArtifacts
+
+      - name: Run Postman Collection
+        run: |
+          newman run test/postman/starting-api.postman_collection.json -e test/postman/starting-api.postman_environment.json --suppress-exit-code -r htmlextra --reporter-htmlextra-export testArtifacts/api-tests-report.html
+
+      - name: Output the results
+        uses: actions/upload-artifact@v2
+        with:
+          name: Reports
+          path: testArtifacts
+
   # https://github.com/snyk/cli, https://github.com/snyk/actions
   # Note: using free tier - called late in pipeline to limit runs
   # Disabled snyk because it don't support Java 17 or Maven with JDK 17 yet

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -372,7 +372,7 @@ jobs:
           allow-repeats: false
           message: |
             DEV deployments have completed successfully!
-            Service API: [https://${{ env.NAME }}-${{ github.event.number }}-service-api.apps.silver.devops.gov.bc.ca/]()
+            Service API: [https://${{ env.NAME }}-${{ github.event.number }}-service-api.apps.silver.devops.gov.bc.ca]()
 
   api-tests:
     name: Newman API tests runner

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -398,10 +398,10 @@ jobs:
 
       - name: Run Postman Collection
         run: |
-          newman run test/postman/starting-api.postman_collection.json --env-var "apiAddr=${{ env.NAME }}-${{ github.event.number }}-service-api.apps.silver.devops.gov.bc.ca" --suppress-exit-code -r htmlextra --reporter-htmlextra-export testArtifacts/api-tests-report.html
+          newman run test/postman/starting-api.postman_collection.json -e test/postman/starting-api.postman_environment.json --env-var "apiAddr=${{ env.NAME }}-${{ github.event.number }}-service-api.apps.silver.devops.gov.bc.ca" --env-var "releaseVer=snapshot-${{ github.event.number }}" --suppress-exit-code -r htmlextra --reporter-htmlextra-export testArtifacts/api-tests-report.html
 
       - name: Output the results
         uses: actions/upload-artifact@v2
         with:
-          name: Reports
+          name: API test report
           path: testArtifacts 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -398,7 +398,7 @@ jobs:
 
       - name: Run Postman Collection
         run: |
-          newman run test/postman/starting-api.postman_collection.json --env-var "apiAddr=https://${{ env.NAME }}-${{ github.event.number }}-service-api.apps.silver.devops.gov.bc.ca" --suppress-exit-code -r htmlextra --reporter-htmlextra-export testArtifacts/api-tests-report.html
+          newman run test/postman/starting-api.postman_collection.json --env-var "apiAddr=${{ env.NAME }}-${{ github.event.number }}-service-api.apps.silver.devops.gov.bc.ca" --suppress-exit-code -r htmlextra --reporter-htmlextra-export testArtifacts/api-tests-report.html
 
       - name: Output the results
         uses: actions/upload-artifact@v2

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -373,3 +373,35 @@ jobs:
           message: |
             DEV deployments have completed successfully!
             Service API: [https://${{ env.NAME }}-${{ github.event.number }}-service-api.apps.silver.devops.gov.bc.ca/]()
+
+  api-tests:
+    name: Newman API tests runner
+    needs:
+      - deploy-dev
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install newman
+        run: |
+          npm install -g newman
+          npm install -g newman-reporter-htmlextra
+
+      - name: Make Directory for Test Results
+        run: mkdir -p testArtifacts
+
+      - name: Run Postman Collection
+        run: |
+          newman run test/postman/starting-api.postman_collection.json --env-var "apiAddr=https://${{ env.NAME }}-${{ github.event.number }}-service-api.apps.silver.devops.gov.bc.ca/" --suppress-exit-code -r htmlextra --reporter-htmlextra-export testArtifacts/api-tests-report.html
+
+      - name: Output the results
+        uses: actions/upload-artifact@v2
+        with:
+          name: Reports
+          path: testArtifacts 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -372,7 +372,7 @@ jobs:
           allow-repeats: false
           message: |
             DEV deployments have completed successfully!
-            Service API: [https://${{ env.NAME }}-${{ github.event.number }}-service-api.apps.silver.devops.gov.bc.ca]()
+            Service API: [https://${{ env.NAME }}-${{ github.event.number }}-service-api.apps.silver.devops.gov.bc.ca/]()
 
   api-tests:
     name: Newman API tests runner
@@ -398,7 +398,7 @@ jobs:
 
       - name: Run Postman Collection
         run: |
-          newman run test/postman/starting-api.postman_collection.json --env-var "apiAddr=https://${{ env.NAME }}-${{ github.event.number }}-service-api.apps.silver.devops.gov.bc.ca/" --suppress-exit-code -r htmlextra --reporter-htmlextra-export testArtifacts/api-tests-report.html
+          newman run test/postman/starting-api.postman_collection.json --env-var "apiAddr=https://${{ env.NAME }}-${{ github.event.number }}-service-api.apps.silver.devops.gov.bc.ca" --suppress-exit-code -r htmlextra --reporter-htmlextra-export testArtifacts/api-tests-report.html
 
       - name: Output the results
         uses: actions/upload-artifact@v2

--- a/test/postman/starting-api.postman_collection.json
+++ b/test/postman/starting-api.postman_collection.json
@@ -1,9 +1,10 @@
 {
 	"info": {
-		"_postman_id": "db559797-d9ba-4bee-93f8-f33c3574ef63",
+		"_postman_id": "4cd8a8d1-1dd6-47ba-8dc9-45f8e4621a07",
 		"name": "starting-api test collection",
 		"description": "## Description\nThis collection contains the API tests of the starting API.\n## Coverage\nThe aim is to have a coverage of 100%, every request on the API should have a mathcing test in this collection.\n## What to test\n- Status code\n- Response body field validation\n- Response time (1s avg)",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "23598385"
 	},
 	"item": [
 		{
@@ -67,7 +68,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{apiAddr}}/users",
+							"raw": "https://{{apiAddr}}/users",
+							"protocol": "https",
 							"host": [
 								"{{apiAddr}}"
 							],
@@ -130,7 +132,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{apiAddr}}/users",
+							"raw": "https://{{apiAddr}}/users",
+							"protocol": "https",
 							"host": [
 								"{{apiAddr}}"
 							],
@@ -194,7 +197,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{apiAddr}}/users",
+							"raw": "https://{{apiAddr}}/users",
+							"protocol": "https",
 							"host": [
 								"{{apiAddr}}"
 							],
@@ -239,7 +243,8 @@
 							}
 						],
 						"url": {
-							"raw": "{{apiAddr}}/users/find-all-by-first-name/John",
+							"raw": "https://{{apiAddr}}/users/find-all-by-first-name/John",
+							"protocol": "https",
 							"host": [
 								"{{apiAddr}}"
 							],
@@ -285,7 +290,8 @@
 							}
 						],
 						"url": {
-							"raw": "{{apiAddr}}/users/find-all-by-first-name/Jane",
+							"raw": "https://{{apiAddr}}/users/find-all-by-first-name/Jane",
+							"protocol": "https",
 							"host": [
 								"{{apiAddr}}"
 							],
@@ -330,7 +336,8 @@
 							}
 						],
 						"url": {
-							"raw": "{{apiAddr}}/users/find-all-by-last-name/Doe",
+							"raw": "https://{{apiAddr}}/users/find-all-by-last-name/Doe",
+							"protocol": "https",
 							"host": [
 								"{{apiAddr}}"
 							],
@@ -374,7 +381,8 @@
 							}
 						],
 						"url": {
-							"raw": "{{apiAddr}}/users/find-all-by-last-name/Doer",
+							"raw": "https://{{apiAddr}}/users/find-all-by-last-name/Doer",
+							"protocol": "https",
 							"host": [
 								"{{apiAddr}}"
 							],
@@ -421,7 +429,8 @@
 							}
 						],
 						"url": {
-							"raw": "{{apiAddr}}/users/find/John/Doe",
+							"raw": "https://{{apiAddr}}/users/find/John/Doe",
+							"protocol": "https",
 							"host": [
 								"{{apiAddr}}"
 							],
@@ -468,7 +477,8 @@
 							}
 						],
 						"url": {
-							"raw": "{{apiAddr}}/users/find/Jane/Doer",
+							"raw": "https://{{apiAddr}}/users/find/Jane/Doer",
+							"protocol": "https",
 							"host": [
 								"{{apiAddr}}"
 							],
@@ -522,7 +532,8 @@
 							}
 						],
 						"url": {
-							"raw": "{{apiAddr}}/users/find-all",
+							"raw": "https://{{apiAddr}}/users/find-all",
+							"protocol": "https",
 							"host": [
 								"{{apiAddr}}"
 							],
@@ -568,7 +579,8 @@
 							}
 						],
 						"url": {
-							"raw": "{{apiAddr}}/users/John/Doe",
+							"raw": "https://{{apiAddr}}/users/John/Doe",
+							"protocol": "https",
 							"host": [
 								"{{apiAddr}}"
 							],
@@ -614,7 +626,8 @@
 							}
 						],
 						"url": {
-							"raw": "{{apiAddr}}/users/Jane/Doer",
+							"raw": "https://{{apiAddr}}/users/Jane/Doer",
+							"protocol": "https",
 							"host": [
 								"{{apiAddr}}"
 							],
@@ -658,12 +671,13 @@
 				"header": [
 					{
 						"key": "Host",
-						"value": "nrbestapi-test-service-api.apps.silver.devops.gov.bc.ca",
+						"value": "{{apiAddr}}",
 						"type": "text"
 					}
 				],
 				"url": {
-					"raw": "{{apiAddr}}/check",
+					"raw": "https://{{apiAddr}}/check",
+					"protocol": "https",
 					"host": [
 						"{{apiAddr}}"
 					],

--- a/test/postman/starting-api.postman_collection.json
+++ b/test/postman/starting-api.postman_collection.json
@@ -658,7 +658,7 @@
 							"pm.test(\"JSON body is valid\", function () {",
 							"    var jsonData = pm.response.json();",
 							"    pm.expect(jsonData.message).to.eql('OK');",
-							"    pm.expect(jsonData.release).to.include('test');",
+							"    pm.expect(jsonData.release).to.include(pm.environment.get(\"releaseVer\"));",
 							"});",
 							""
 						],

--- a/test/postman/starting-api.postman_environment.json
+++ b/test/postman/starting-api.postman_environment.json
@@ -1,14 +1,14 @@
 {
-	"id": "61c27c71-bb65-4395-b906-3c60c55ef801",
+	"id": "b5b2a1ec-47ba-4df9-89eb-cef9a91633c4",
 	"name": "starting-api env",
 	"values": [
 		{
 			"key": "apiAddr",
-			"value": "https://nrbestapi-test-service-api.apps.silver.devops.gov.bc.ca",
+			"value": "nrbestapi-test-service-api.apps.silver.devops.gov.bc.ca",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-09-15T13:43:33.249Z",
-	"_postman_exported_using": "Postman/7.36.5"
+	"_postman_exported_at": "2022-09-29T16:54:14.506Z",
+	"_postman_exported_using": "Postman/9.31.13"
 }

--- a/test/postman/starting-api.postman_environment.json
+++ b/test/postman/starting-api.postman_environment.json
@@ -6,9 +6,15 @@
 			"key": "apiAddr",
 			"value": "nrbestapi-test-service-api.apps.silver.devops.gov.bc.ca",
 			"enabled": true
+		},
+		{
+			"key": "releaseVer",
+			"value": "test",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-09-29T16:54:14.506Z",
+	"_postman_exported_at": "2022-09-30T12:47:21.057Z",
 	"_postman_exported_using": "Postman/9.31.13"
 }


### PR DESCRIPTION
# Description

Included Newman to run on the `pr-close` and `merge-to-main` workflows so it can automatically run the API tests from the Postman collection on every build, it's also added the ability to generate the test report in HTML format.

Fixes # FSADT2-74

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally with the same commands on Newman.

## Checklist

- [x ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have already been accepted and merged


## Further comments

Jira ticket: [FSADT2-74](https://apps.nrs.gov.bc.ca/int/jira/browse/FSADT2-74)

