### PR TITLE
ci(docker): updating docker release strategy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,14 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
+      - name: Creating temp folder
+        run: mkdir -p target/
+
       - name: Getting artifact
         uses: actions/download-artifact@v3
         with:
           name: service
-          path: ./
+          path: target/
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,37 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+
+  artifact:
+    name: Build artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Cache Maven
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-test-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-test-
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Generate Artifact
+        run: mvn -B --no-transfer-progress clean package -DskipTests -Dtests.skip=true -Dskip.unit.tests=true --file pom.xml
+
+      - name: Saving artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: service
+          path: target/backend-start-api.jar
+          retention-days: 1
+
   push_to_registry:
     name: Push Docker image
     runs-on: ubuntu-latest
@@ -20,6 +51,12 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+
+      - name: Getting artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: service
+          path: ./
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-FROM maven:3.8.6-openjdk-18-slim AS build
-
-COPY src /home/app/src
-COPY pom.xml /home/app
-RUN mvn --no-transfer-progress -f /home/app/pom.xml clean package
-
-FROM docker.io/openjdk:17-alpine
+FROM eclipse-temurin:17-jre-alpine
 LABEL maintainer="Ricardo Montania Prado de Campos <ricardo.campos@encora.com>"
 
 WORKDIR /usr/share/service/
@@ -16,14 +10,9 @@ ENV LANG en_CA.UTF-8
 ENV LANGUAGE en_CA.UTF-8
 ENV LC_ALL en_CA.UTF-8
 
-ENV HEAP_LOG_PATH /usr/share/service/dump
-ENV JAVA_OPS -Xms256m -Xmx512m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$HEAP_LOG_PATH
-ENV JAVA_DEBUG_OPS -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -Xloggc:$HEAP_LOG_PATH/garbage-collection.log
-ENV DEBUG_MODE false
-
 COPY InstallCert.java .
 
-COPY --from=build /home/app/target/*.jar /usr/share/service/service.jar
+COPY ./backend-start-api.jar /usr/share/service/service.jar
 COPY dockerfile-entrypoint.sh /usr/share/service/dockerfile-entrypoint.sh
 RUN chmod -R g+w . && \
     chmod g+x dockerfile-entrypoint.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV LC_ALL en_CA.UTF-8
 
 COPY InstallCert.java .
 
-COPY ./backend-start-api.jar /usr/share/service/service.jar
+COPY ./target/backend-start-api.jar /usr/share/service/service.jar
 COPY dockerfile-entrypoint.sh /usr/share/service/dockerfile-entrypoint.sh
 RUN chmod -R g+w . && \
     chmod g+x dockerfile-entrypoint.sh && \

--- a/dockerfile-entrypoint.sh
+++ b/dockerfile-entrypoint.sh
@@ -1,14 +1,10 @@
 #!/bin/sh
 
-DEBUG_PRINT=`$DEBUG_MODE -eq true && echo $JAVA_DEBUG_OPS || echo ""`
-
 java --source 17 InstallCert.java --quiet "${DATABASE_HOST}:${DATABASE_PORT}"
 keytool -exportcert -alias "${DATABASE_HOST}-1" -keystore jssecacerts -storepass changeit -file oracle.cer
 keytool -importcert -alias orakey -noprompt -cacerts -storepass changeit -file oracle.cer
 
 java \
     -Djava.security.egd=file:/dev/./urandom \
-    $JAVA_OPS \
-    $DEBUG_PRINT \
     -jar \
     /usr/share/service/service.jar


### PR DESCRIPTION
updating release strategy for docker, to reduce the amount of time it takes to release by leveraging maven build process and cache.

removed some of the java ops and debug ops due to possible conflicts with java 17.

<!-- Provide a general summary of your changes in the Title above -->

# Description

Changed the release strategy to leverage the GitHub actions cache to build the artifact before packing it into an image.

Also removed a few parameters that don't make any sense at the moment (mostly memory cap and heap dump).

Changed the base image from JDK to JRE, as this will reduce the final image size and reduce the available attack surface. A small caveat is that with the removal of the JDK, it could generate some error messages due to some of the capabilities being removed (like code compilation).

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

A local image was generated and executed to make sure the process was done correctly.

- [x] Generated a new local image
- [x] Executed the new local image


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged

## Further comments

As this changes removes the JDK, it will make anything that requires code compilation to be reworked
