### PR TITLE
feat(hikari): adding hikari configuration

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,13 @@ spring.datasource.driver-class-name=oracle.jdbc.driver.OracleDriver
 spring.datasource.url = jdbc:oracle:thin:@tcps://${DATABASE_HOST}:${DATABASE_PORT}/${SERVICE_NAME}
 spring.datasource.username = ${DATABASE_USER}
 spring.datasource.password = ${DATABASE_PASSWORD}
+spring.datasource.hikari.connectionTimeout = 90000
+spring.datasource.hikari.idleTimeout = 45000
+spring.datasource.hikari.maxLifetime = 60000
+spring.datasource.hikari.keepaliveTime = 30000
+spring.datasource.hikari.poolName = NrBeApiPool
+spring.datasource.hikari.minimumIdle = 1
+spring.datasource.hikari.maximumPoolSize = 3
 spring.jpa.database-platform=org.hibernate.dialect.Oracle12cDialect
 
 # Actuator and ops


### PR DESCRIPTION
# Description

adding Hikari connection pool configuration to change the default connection pool configuration.

this will allow us to have more flexibility on how should we handle the number of connections being used.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Hikari will not introduce anything new but instead will configure the connection pool of our application.

- [ ] Check the session/connection on the database before starting the app. Should not have any connection open from our app.
- [ ] Spin the app and check the session/connection, it should have a single one
- [ ] Execute a few requests and check the session/connection, it should have at most 3 connections
- [ ] Stop de application and check the session/connection, it should have no more connections from our app pending


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

The provided values are just for reference and can be changed/tweaked if required. It can also be replaced by external parameters in order to allow per-environment configuration.
