### PR TITLE
fix: use dev credentials in test and prod for now

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -220,8 +220,8 @@ jobs:
           token: ${{ secrets.VAULT_TOKEN }}
           exportEnv: 'false'
           secrets: |
-            apps/data/test/spar/app-spar/db_proxy_read_only db_username | VAULT_DB_USER;
-            apps/data/test/spar/app-spar/db_proxy_read_only db_password | VAULT_DB_PASS;
+            apps/data/dev/spar/app-spar/db_proxy_read_only db_username | VAULT_DB_USER;
+            apps/data/dev/spar/app-spar/db_proxy_read_only db_password | VAULT_DB_PASS;
 
       - uses: actions/checkout@v3
       - name: Print NRBESTAPI_VERSION env
@@ -413,8 +413,8 @@ jobs:
           token: ${{ secrets.VAULT_TOKEN }}
           exportEnv: 'false'
           secrets: |
-            apps/data/prod/spar/app-spar/db_proxy_read_only db_username | VAULT_DB_USER;
-            apps/data/prod/spar/app-spar/db_proxy_read_only db_password | VAULT_DB_PASS;
+            apps/data/dev/spar/app-spar/db_proxy_read_only db_username | VAULT_DB_USER;
+            apps/data/dev/spar/app-spar/db_proxy_read_only db_password | VAULT_DB_PASS;
 
       - uses: actions/checkout@v3
       - name: Print NRBESTAPI_VERSION env

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -214,7 +214,7 @@ jobs:
     steps:
       - name: Import Secrets
         id: secrets
-        uses: hashicorp/vault-action@v2
+        uses: hashicorp/vault-action@v2.2.0
         with:
           url: https://vault-iit.apps.silver.devops.gov.bc.ca
           token: ${{ secrets.VAULT_TOKEN }}
@@ -407,7 +407,7 @@ jobs:
 
       - name: Import Secrets
         id: secrets
-        uses: hashicorp/vault-action@v2
+        uses: hashicorp/vault-action@v2.2.0
         with:
           url: https://vault-iit.apps.silver.devops.gov.bc.ca
           token: ${{ secrets.VAULT_TOKEN }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -338,7 +338,7 @@ jobs:
     steps:
       - name: Import Secrets
         id: secrets
-        uses: hashicorp/vault-action@v2
+        uses: hashicorp/vault-action@v2.2.0
         with:
           url: https://vault-iit.apps.silver.devops.gov.bc.ca
           token: ${{ secrets.VAULT_TOKEN }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Hardcode database credentials path to use secrets from dev even in test and prod.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Using Pull Requests and actions.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
