### PR TITLE
build(dev): disable authentication and authorization for local development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,12 +70,11 @@ You can check your code before submitting with `./mvnw --no-transfer-progress ch
 
 After setting up your environment you might want to see this service running. 
 You can get it up and running by typing `./mvnw spring-boot:run` in the project
-root directory.
+root directory (add the `-Dprofile=dev` option to disable the need for authentication
+and authorisation.
 
 In case you want to debug with remote JVM, you can do it with this command:
 `./mvnw spring-boot:run -Dspring-boot.run.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"`
-
-Note: TODO add here about database and running HOW-TOs.
 
 ## Run tests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM eclipse-temurin:17-jdk-alpine
 LABEL maintainer="Ricardo Montania Prado de Campos <ricardo.campos@encora.com>"
 
+RUN mkdir -p /usr/share/service/
 WORKDIR /usr/share/service/
-RUN mkdir -p /usr/share/service/config
-RUN mkdir -p /usr/share/service/dump
-RUN mkdir -p /usr/share/service/public
-RUN mkdir -p /usr/share/service/artifacts
+
+RUN mkdir config
+RUN mkdir dump
+RUN mkdir public
+RUN mkdir artifacts
 
 ENV LANG en_CA.UTF-8
 ENV LANGUAGE en_CA.UTF-8
@@ -14,8 +16,8 @@ ENV LC_ALL en_CA.UTF-8
 COPY InstallCert.java .
 COPY HealthCheck.java .
 
-COPY ./target/backend-start-api.jar /usr/share/service/artifacts/backend-start-api.jar
-COPY dockerfile-entrypoint.sh /usr/share/service/dockerfile-entrypoint.sh
+COPY target/backend-start-api.jar artifacts/backend-start-api.jar
+COPY dockerfile-entrypoint.sh dockerfile-entrypoint.sh
 RUN chmod -R g+w . && \
     chmod g+x dockerfile-entrypoint.sh && \
     chmod g+w ${JAVA_HOME}/lib/security/cacerts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,7 @@ services:
       context: .
     container_name: backend
     dns: ${DNS_ADDRESS}
-    environment:
-      NRBESTAPI_VERSION: ${NRBESTAPI_VERSION}
-      DATABASE_HOST: ${DATABASE_HOST}
-      DATABASE_PORT: ${DATABASE_PORT}
-      SERVICE_NAME: ${SERVICE_NAME}
-      DATABASE_USER: ${DATABASE_USER}
-      DATABASE_PASSWORD: ${DATABASE_PASSWORD}
-      KEYCLOAK_REALM_URL: ${KEYCLOAK_REALM_URL}
+    env_file: .env
     healthcheck:
       test: ["CMD", "java", "HealthCheck"]
       interval: 1m30s

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<skip.unit.tests>false</skip.unit.tests>
 		<jacoco.skip>true</jacoco.skip>
 		<checkstyle.skip>true</checkstyle.skip>
-    	<checkstyle.failsOnError>true</checkstyle.failsOnError>
+		<checkstyle.failsOnError>true</checkstyle.failsOnError>
 		<checkstyle.includeTestSourceDirectory>true</checkstyle.includeTestSourceDirectory>
 		<jacoco.output.data>${project.build.directory}/coverage-reports</jacoco.output.data>
 		<timestamp>${maven.build.timestamp}</timestamp>

--- a/src/main/java/ca/bc/gov/backendstartapi/config/dev/MethodSecurityConfig.java
+++ b/src/main/java/ca/bc/gov/backendstartapi/config/dev/MethodSecurityConfig.java
@@ -1,7 +1,7 @@
 package ca.bc.gov.backendstartapi.config.dev;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 /**
@@ -10,6 +10,6 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
  * @see EnableMethodSecurity
  */
 @Configuration
+@Profile("dev")
 @EnableMethodSecurity(prePostEnabled = false)
-@ConditionalOnProperty(value = "authorisation.enabled", havingValue = "false")
 public class MethodSecurityConfig {}

--- a/src/main/java/ca/bc/gov/backendstartapi/config/dev/MethodSecurityConfig.java
+++ b/src/main/java/ca/bc/gov/backendstartapi/config/dev/MethodSecurityConfig.java
@@ -1,0 +1,15 @@
+package ca.bc.gov.backendstartapi.config.dev;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+
+/**
+ * Disables authorisation in annotated REST endpoints.
+ *
+ * @see EnableMethodSecurity
+ */
+@Configuration
+@EnableMethodSecurity(prePostEnabled = false)
+@ConditionalOnProperty(value = "authorisation.enabled", havingValue = "false")
+public class MethodSecurityConfig {}

--- a/src/main/java/ca/bc/gov/backendstartapi/config/dev/WebSecurityConfig.java
+++ b/src/main/java/ca/bc/gov/backendstartapi/config/dev/WebSecurityConfig.java
@@ -1,8 +1,8 @@
 package ca.bc.gov.backendstartapi.config.dev;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -14,8 +14,8 @@ import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
  * <p>To be used for <strong>local development only.</strong>
  */
 @Configuration
+@Profile("dev")
 @EnableWebSecurity
-@ConditionalOnProperty(name = "authentication.enabled", havingValue = "false")
 public class WebSecurityConfig {
 
   /** Authorize all HTTP requests. */

--- a/src/main/java/ca/bc/gov/backendstartapi/config/dev/WebSecurityConfig.java
+++ b/src/main/java/ca/bc/gov/backendstartapi/config/dev/WebSecurityConfig.java
@@ -1,0 +1,34 @@
+package ca.bc.gov.backendstartapi.config.dev;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+
+/**
+ * Configurations for authentication in REST endpoints.
+ *
+ * <p>To be used for <strong>local development only.</strong>
+ */
+@Configuration
+@EnableWebSecurity
+@ConditionalOnProperty(name = "authentication.enabled", havingValue = "false")
+public class WebSecurityConfig {
+
+  /** Authorize all HTTP requests. */
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.cors()
+        .and()
+        .csrf()
+        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+        .and()
+        .authorizeHttpRequests()
+        .anyRequest()
+        .permitAll();
+    return http.build();
+  }
+}

--- a/src/main/java/ca/bc/gov/backendstartapi/config/prod/CorsConfig.java
+++ b/src/main/java/ca/bc/gov/backendstartapi/config/prod/CorsConfig.java
@@ -1,4 +1,4 @@
-package ca.bc.gov.backendstartapi.config;
+package ca.bc.gov.backendstartapi.config.prod;
 
 import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/ca/bc/gov/backendstartapi/config/prod/MethodSecurityConfig.java
+++ b/src/main/java/ca/bc/gov/backendstartapi/config/prod/MethodSecurityConfig.java
@@ -1,7 +1,7 @@
 package ca.bc.gov.backendstartapi.config.prod;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 /**
@@ -10,6 +10,6 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
  * @see EnableMethodSecurity
  */
 @Configuration
+@Profile("!dev")
 @EnableMethodSecurity
-@ConditionalOnProperty(value = "authorisation.enabled", havingValue = "true", matchIfMissing = true)
 public class MethodSecurityConfig {}

--- a/src/main/java/ca/bc/gov/backendstartapi/config/prod/MethodSecurityConfig.java
+++ b/src/main/java/ca/bc/gov/backendstartapi/config/prod/MethodSecurityConfig.java
@@ -1,0 +1,15 @@
+package ca.bc.gov.backendstartapi.config.prod;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+
+/**
+ * Enables authorisation in annotated REST endpoints.
+ *
+ * @see EnableMethodSecurity
+ */
+@Configuration
+@EnableMethodSecurity
+@ConditionalOnProperty(value = "authorisation.enabled", havingValue = "true", matchIfMissing = true)
+public class MethodSecurityConfig {}

--- a/src/main/java/ca/bc/gov/backendstartapi/config/prod/WebSecurityConfig.java
+++ b/src/main/java/ca/bc/gov/backendstartapi/config/prod/WebSecurityConfig.java
@@ -4,13 +4,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.GrantedAuthority;
@@ -22,8 +21,8 @@ import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 /** Configurations for authentication in REST endpoints. */
 @Configuration
+@Profile("!dev")
 @EnableWebSecurity
-@ConditionalOnProperty(name = "authentication.enabled", havingValue = "true", matchIfMissing = true)
 public class WebSecurityConfig {
 
   @Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}")

--- a/src/main/java/ca/bc/gov/backendstartapi/config/prod/WebSecurityConfig.java
+++ b/src/main/java/ca/bc/gov/backendstartapi/config/prod/WebSecurityConfig.java
@@ -1,9 +1,10 @@
-package ca.bc.gov.backendstartapi.config;
+package ca.bc.gov.backendstartapi.config.prod;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
@@ -19,11 +20,11 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
-/** This class contains all configurations related to security and authentication. */
+/** Configurations for authentication in REST endpoints. */
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity
-public class SecurityConfig {
+@ConditionalOnProperty(name = "authentication.enabled", havingValue = "true", matchIfMissing = true)
+public class WebSecurityConfig {
 
   @Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}")
   String jwkSetUri;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,11 @@
+# Spring profile; may be set with the shorthand "profile"
+spring.profiles.active=${profile:prod}
+
 # Server and application
 spring.application.name = nr-fsa-service-api-4139
 server.port = 8090
 
 # Authentication and security
-authentication.enabled=${AUTHENTICATION_ENABLED:true}
-authorisation.enabled=${AUTHORISATION_ENABLED:true}
 keycloak-auth = ${KEYCLOAK_REALM_URL:https://empty.com/auth}
 spring.security.oauth2.resourceserver.jwt.issuer-uri = ${keycloak-auth}
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri = ${keycloak-auth}/protocol/openid-connect/certs

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,9 @@
 spring.application.name = nr-fsa-service-api-4139
 server.port = 8090
 
-# Key Cloak, authentication and security
+# Authentication and security
+authentication.enabled=${AUTHENTICATION_ENABLED:true}
+authorisation.enabled=${AUTHORISATION_ENABLED:true}
 keycloak-auth = ${KEYCLOAK_REALM_URL:https://empty.com/auth}
 spring.security.oauth2.resourceserver.jwt.issuer-uri = ${keycloak-auth}
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri = ${keycloak-auth}/protocol/openid-connect/certs


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Create configurations to be used for local development which turn off authentication and authorization of the REST endpoints. As of right now, the only way for getting the credentials needed known to us that is 100% dependable is to run the front-end application and login through there, which is a hassle if you just need to work with the back-end.

This configuration can be activated when both the `AUTHENTICATION_ENABLED` and `AUTHORISATION_ENABLED` environment variables are set to `false`.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
