### PR TITLE
build(database): use org.hibernate.dialect.OracleDialect

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,7 +19,7 @@ spring.datasource.hikari.keepaliveTime = 30000
 spring.datasource.hikari.poolName = NrBeApiPool
 spring.datasource.hikari.minimumIdle = 1
 spring.datasource.hikari.maximumPoolSize = 3
-spring.jpa.database-platform=org.hibernate.dialect.Oracle12cDialect
+spring.jpa.database-platform=org.hibernate.dialect.OracleDialect
 
 # Actuator and ops
 management.endpoint.health.show-details = always


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Use `org.hibernate.dialect.OracleDialect` instead of the deprecated `org.hibernate.dialect.Oracle12cDialect`, as warned by the application as it starts:

```
2023-01-24T11:23:14.809-03:00  INFO 126005 --- [           main] SQL dialect                              : HHH000400: Using dialect: org.hibernate.dialect.Oracle12cDialect
2023-01-24T11:23:14.810-03:00  WARN 126005 --- [           main] org.hibernate.orm.deprecation            : HHH90000026: Oracle12cDialect has been deprecated; use org.hibernate.dialect.OracleDialect instead
```